### PR TITLE
22 create tests for pyramid chart

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,3 +27,6 @@ Imports:
 Depends: 
     R (>= 2.10)
 LazyData: true
+Suggests: 
+    testthat (>= 3.0.0)
+Config/testthat/edition: 3

--- a/R/pyramid_chart.R
+++ b/R/pyramid_chart.R
@@ -43,6 +43,15 @@ pyramid_chart <-
     data_filtered <- data[!is.na(data[[xvar]]), ]  # Filter out NA values
     figlimits <- c(-1, 1) * ceiling(max(abs(data_filtered[[xvar]])) / 10) * 10
 
+    # Convert levelvar to factor or character if not already
+    if (is.numeric(data_filtered[[levelvar]]) |
+        is.character(data_filtered[[levelvar]])) {
+      data_filtered[[levelvar]] <- as.factor(data_filtered[[levelvar]])
+    } else if (!is.factor(data_filtered[[levelvar]]) &&
+               !is.character(data_filtered[[levelvar]])) {
+      stop("levelvar should be a factor, character, or numeric vector")
+    }
+
     scale_x <- scale_x_continuous(
       limits = ~figlimits,
       breaks = seq(figlimits[1], figlimits[2], 10),

--- a/R/pyramid_chart.R
+++ b/R/pyramid_chart.R
@@ -40,15 +40,15 @@ pyramid_chart <-
            xlab,
            alpha_set,
            chartcolors) {
-    data_filtered <- data[!is.na(data[[xvar]]), ]  # Filter out NA values
+    data_filtered <- data[!is.na(data[[xvar]]), ] # Filter out NA values
     figlimits <- c(-1, 1) * ceiling(max(abs(data_filtered[[xvar]])) / 10) * 10
 
     # Convert levelvar to factor or character if not already
     if (is.numeric(data_filtered[[levelvar]]) |
-        is.character(data_filtered[[levelvar]])) {
+      is.character(data_filtered[[levelvar]])) {
       data_filtered[[levelvar]] <- as.factor(data_filtered[[levelvar]])
     } else if (!is.factor(data_filtered[[levelvar]]) &&
-               !is.character(data_filtered[[levelvar]])) {
+      !is.character(data_filtered[[levelvar]])) {
       stop("levelvar should be a factor, character, or numeric vector")
     }
 

--- a/R/pyramid_chart.R
+++ b/R/pyramid_chart.R
@@ -40,8 +40,8 @@ pyramid_chart <-
            xlab,
            alpha_set,
            chartcolors) {
-    figlimits <-
-      c(-1, 1) * ceiling(max(abs(data[[xvar]])) / 10) * 10
+    data_filtered <- data[!is.na(data[[xvar]]), ]  # Filter out NA values
+    figlimits <- c(-1, 1) * ceiling(max(abs(data_filtered[[xvar]])) / 10) * 10
 
     scale_x <- scale_x_continuous(
       limits = ~figlimits,
@@ -49,7 +49,7 @@ pyramid_chart <-
       labels = abs(seq(figlimits[1], figlimits[2], 10))
     )
 
-    fig2_1 <- data |>
+    fig2_1 <- data_filtered |>
       filter(.data[[levelvar]] == levels(.data[[levelvar]])[[1]]) |>
       ggplot(aes(
         x = .data[[xvar]],
@@ -76,7 +76,7 @@ pyramid_chart <-
         axis_line = element_blank()
       )
 
-    fig2_2 <- data |>
+    fig2_2 <- data_filtered |>
       filter(.data[[levelvar]] == levels(.data[[levelvar]])[[2]]) |>
       ggplot(aes(
         x = .data[[xvar]],

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,12 @@
+# This file is part of the standard setup for testthat.
+# It is recommended that you do not modify it.
+#
+# Where should you do additional test configuration?
+# Learn more about the roles of various files in:
+# * https://r-pkgs.org/testing-design.html#sec-tests-files-overview
+# * https://testthat.r-lib.org/articles/special-files.html
+
+library(testthat)
+library(brcharts)
+
+test_check("brcharts")

--- a/tests/testthat/test-pyramid_chart.R
+++ b/tests/testthat/test-pyramid_chart.R
@@ -1,7 +1,7 @@
 library(testthat)
 
 # Create a sample data frame
-demography <- data.frame(
+demodata <- data.frame(
   Type = c(1, 1, 2, 2),
   Gender = c("Females", "Males", "Females", "Males"),
   Age = c(20, 20, 30, 30),
@@ -9,7 +9,7 @@ demography <- data.frame(
 )
 
 test_that("pyramid_chart returns a ggplot object", {
-  result <- demography |>
+  result <- demodata |>
     dplyr::mutate(
       Type = as.factor(paste0("Type ", Type)),
       figprev = ifelse(Gender == "Females", -1 * Prevalence / 100000, Prevalence / 100000),
@@ -25,10 +25,10 @@ test_that("pyramid_chart returns a ggplot object", {
 })
 
 test_that("pyramid_chart handles missing data correctly", {
-  demography_missing <- demography
-  demography_missing$Prevalence[1] <- NA
+  demodata_missing <- demodata
+  demodata_missing$Prevalence[1] <- NA
 
-  result <- demography_missing |>
+  result <- demodata_missing |>
     dplyr::mutate(
       Type = as.factor(paste0("Type ", Type)),
       figprev = ifelse(Gender == "Females", -1 * Prevalence / 100000, Prevalence / 100000),
@@ -45,13 +45,13 @@ test_that("pyramid_chart handles missing data correctly", {
 
 test_that("pyramid_chart handles different input types correctly", {
   # Test with numeric input
-  result <- demography |>
+  result <- demodata |>
     dplyr::mutate(
       figprev = ifelse(Gender == "Females", -1 * Prevalence / 100000, Prevalence / 100000),
       Sex = Gender
     ) |>
     pyramid_chart(
-      levelvar = Type, xvar = "figprev", yvar = "Age",
+      levelvar = "Type", xvar = "figprev", yvar = "Age",
       groupvar = "Sex", alpha_set = 0.7, chartcolors = c("#FF0000", "#0000FF"),
       xlab = "Prevalence (x 100 000)"
     )
@@ -59,7 +59,7 @@ test_that("pyramid_chart handles different input types correctly", {
   expect_true(inherits(result, "ggplot"))
 
   # Test with character input
-  result <- demography |>
+  result <- demodata |>
     dplyr::mutate(
       Type = as.character(Type),
       figprev = ifelse(Gender == "Females", -1 * Prevalence / 100000, Prevalence / 100000),

--- a/tests/testthat/test-pyramid_chart.R
+++ b/tests/testthat/test-pyramid_chart.R
@@ -1,0 +1,75 @@
+library(testthat)
+
+# Create a sample data frame
+demography <- data.frame(
+  Type = c(1, 1, 2, 2),
+  Gender = c("Females", "Males", "Females", "Males"),
+  Age = c(20, 20, 30, 30),
+  Prevalence = c(100, 200, 150, 250)
+)
+
+test_that("pyramid_chart returns a ggplot object", {
+  result <- demography |>
+    dplyr::mutate(
+      Type = as.factor(paste0("Type ", Type)),
+      figprev = ifelse(Gender == "Females", -1 * Prevalence / 100000, Prevalence / 100000),
+      Sex = Gender
+    ) |>
+    pyramid_chart(
+      levelvar = "Type", xvar = "figprev", yvar = "Age",
+      groupvar = "Sex", alpha_set = 0.7, chartcolors = c("#FF0000", "#0000FF"),
+      xlab = "Prevalence (x 100 000)"
+    )
+
+  expect_true(inherits(result, "ggplot"))
+})
+
+test_that("pyramid_chart handles missing data correctly", {
+  demography_missing <- demography
+  demography_missing$Prevalence[1] <- NA
+
+  result <- demography_missing |>
+    dplyr::mutate(
+      Type = as.factor(paste0("Type ", Type)),
+      figprev = ifelse(Gender == "Females", -1 * Prevalence / 100000, Prevalence / 100000),
+      Sex = Gender
+    ) |>
+    pyramid_chart(
+      levelvar = "Type", xvar = "figprev", yvar = "Age",
+      groupvar = "Sex", alpha_set = 0.7, chartcolors = c("#FF0000", "#0000FF"),
+      xlab = "Prevalence (x 100 000)"
+    )
+
+  expect_true(inherits(result, "ggplot"))
+})
+
+test_that("pyramid_chart handles different input types correctly", {
+  # Test with numeric input
+  result <- demography |>
+    dplyr::mutate(
+      figprev = ifelse(Gender == "Females", -1 * Prevalence / 100000, Prevalence / 100000),
+      Sex = Gender
+    ) |>
+    pyramid_chart(
+      levelvar = Type, xvar = "figprev", yvar = "Age",
+      groupvar = "Sex", alpha_set = 0.7, chartcolors = c("#FF0000", "#0000FF"),
+      xlab = "Prevalence (x 100 000)"
+    )
+
+  expect_true(inherits(result, "ggplot"))
+
+  # Test with character input
+  result <- demography |>
+    dplyr::mutate(
+      Type = as.character(Type),
+      figprev = ifelse(Gender == "Females", -1 * Prevalence / 100000, Prevalence / 100000),
+      Sex = Gender
+    ) |>
+    pyramid_chart(
+      levelvar = "Type", xvar = "figprev", yvar = "Age",
+      groupvar = "Sex", alpha_set = 0.7, chartcolors = c("#FF0000", "#0000FF"),
+      xlab = "Prevalence (x 100 000)"
+    )
+
+  expect_true(inherits(result, "ggplot"))
+})


### PR DESCRIPTION
Added test suite to include the following tests:

1. Test that pyramid_chart returns a ggplot object: This test checks if the pyramid_chart function returns a ggplot object when provided with valid input data.
2. Test that pyramid_chart handles missing data correctly: This test checks if the pyramid_chart function can handle missing data in the input data frame without causing errors.
3. Test that pyramid_chart handles different input types correctly: This test checks if the pyramid_chart function can handle different input types (numeric and character) for the levelvar argument without causing errors.

I've updated the pyramid_chart function inline with the tests.